### PR TITLE
🐛 [bug] Removed cancellation of non-cancellable event (touchmove)

### DIFF
--- a/lib/DatePickerItem.js
+++ b/lib/DatePickerItem.js
@@ -241,7 +241,9 @@ class DatePickerItem extends Component<void, Props, State> {
      * @return {undefined}
      */
     handleContentTouch(event) {
-        event.preventDefault();
+        if (event.cancelable) {
+            event.preventDefault();
+        }
         if (this.animating) return;
         if (event.type === 'touchstart') {
             this.handleStart(event);


### PR DESCRIPTION
Commit solves a problem when the preventDefault method was called on an event with cancelable = false
![image](https://user-images.githubusercontent.com/9928071/100349613-c72e6200-2ff9-11eb-8d5d-2fee60f4b4d3.png)
